### PR TITLE
[MRIS-9][FE] Linter / Formatter の設定

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": true
+}

--- a/README.md
+++ b/README.md
@@ -82,6 +82,46 @@ yarn dev
 ---
 
 
+## Linter / Formatter - ESLint / Prettier
+
+このプロジェクトでは **JavaScript / TypeScript のコード整形および静的解析ツール**として **ESLint** と **Prettier** を使用しています。
+
+---
+
+### 使用目的
+
+#### ESLint  
+- 構文エラーやバグの検出
+- 型の不整合や未使用変数の検出
+- React Hooks のルール違反チェック
+- チームで統一されたコードスタイルの維持
+
+#### Prettier  
+- 自動コード整形
+- セミコロン、インデント、クォートなどのスタイル統一
+- 保存時のフォーマット対応
+
+---
+
+### CLI での実行方法
+
+```bash
+# ESLint によるコードチェック
+yarn lint
+
+# ESLint による自動修正を含むチェック
+yarn lint:fix
+
+# Prettier によるフォーマットチェック
+yarn format
+
+# Prettier による自動整形
+yarn format:fix
+```
+
+---
+
+
 ## GitHub ブランチ運用ルール
 
 ### ブランチ一覧と役割

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,21 +3,46 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
-import { globalIgnores } from 'eslint/config'
+import react from 'eslint-plugin-react'
 
-export default tseslint.config([
-  globalIgnores(['dist']),
+export default tseslint.config(
+  { ignores: ['dist'] },
   {
+    extends: [js.configs.recommended, ...tseslint.configs.strictTypeChecked, ...tseslint.configs.stylisticTypeChecked,],
     files: ['**/*.{ts,tsx}'],
-    extends: [
-      js.configs.recommended,
-      tseslint.configs.recommended,
-      reactHooks.configs['recommended-latest'],
-      reactRefresh.configs.vite,
-    ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+       project: ['./tsconfig.node.json', './tsconfig.app.json', './tsconfig.test.json'],
+       tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+      react
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+      ...react.configs.recommended.rules,
+      ...react.configs['jsx-runtime'].rules,
+      '@typescript-eslint/consistent-type-definitions': 'off',
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
     },
   },
-])
+  {
+    files: ['**/*.test.ts', '**/*.test.tsx'],
+    rules: {
+      '@typescript-eslint/no-empty-function': 'off',
+    },
+  },
+)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,16 +9,16 @@ function App() {
   return (
     <>
       <div>
-        <a href="https://vite.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank" rel="noreferrer">
           <img src={viteLogo} className="logo" alt="Vite logo" />
         </a>
-        <a href="https://react.dev" target="_blank">
+        <a href="https://react.dev" target="_blank" rel="noreferrer">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
+        <button onClick={() => { setCount((count) => count + 1); }}>
           count is {count}
         </button>
         <p>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## 概要

- Linter / Formatter として使用するESLint + Prettierの設定を追加し、CLIでの実行方法をREADMEに追記

## 変更内容

- READMEにCLIでの実行方法を追記
- .prettierrc にフォーマットルールを定義
- eslint.config.js にルールと拡張設定を追記
- App.tsx, main.tsx に対して Linter による指摘（例: rel="noopener noreferrer" 追加、void式の修正）を反映

## 影響範囲

- なし