### PR TITLE
[MRIS-59]存在しないurlを叩くと404ページに遷移する

### DIFF
--- a/src/features/Error/NotFound/NotFoundContainer.tsx
+++ b/src/features/Error/NotFound/NotFoundContainer.tsx
@@ -1,0 +1,5 @@
+import { NotFoundPresentational } from './NotFoundPresentational';
+
+export const NotFoundContainer = () => {
+  return <NotFoundPresentational />;
+};

--- a/src/features/Error/NotFound/NotFoundPresentational.tsx
+++ b/src/features/Error/NotFound/NotFoundPresentational.tsx
@@ -1,0 +1,22 @@
+import { Header } from '@/components/organisms/Header';
+import { Box, Container, Stack } from '@chakra-ui/react';
+
+export const NotFoundPresentational = () => {
+  return (
+    <>
+      <Header />
+      <Container>
+        <Stack align='center' justify='center' minH='60vh'>
+          <Box textAlign='center'>
+            <Box fontSize='6xl' fontWeight='bold' color='#a9c9eb'>
+              404
+            </Box>
+            <Box fontSize='2xl' mt={2}>
+              Page Not Found
+            </Box>
+          </Box>
+        </Stack>
+      </Container>
+    </>
+  );
+};

--- a/src/features/Error/NotFound/__test__/NotFoundContainer.test.tsx
+++ b/src/features/Error/NotFound/__test__/NotFoundContainer.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import { NotFoundContainer } from '../NotFoundContainer';
+import { customRender } from '@/tests/helpers/customRender';
+import * as Presentational from '../NotFoundPresentational';
+
+vi.spyOn(Presentational, 'NotFoundPresentational').mockImplementation(() => (
+  <div data-testid='mock-presentational'>Page Not Found</div>
+));
+
+describe('NotFoundContainer', () => {
+  it('NotFoundPresentationalが表示されること', () => {
+    customRender(<NotFoundContainer />);
+    expect(screen.getByTestId('mock-presentational')).toBeInTheDocument();
+  });
+});

--- a/src/features/Error/NotFound/__test__/NotFoundPresentational.test.tsx
+++ b/src/features/Error/NotFound/__test__/NotFoundPresentational.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import { NotFoundPresentational } from '../NotFoundPresentational';
+import { customRender } from '@/tests/helpers/customRender';
+
+describe('NotFoundPresentational', () => {
+  it('Page Not Found が表示されること', () => {
+    customRender(<NotFoundPresentational />);
+    expect(screen.getByText('Page Not Found')).toBeInTheDocument();
+  });
+});

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -1,12 +1,14 @@
 import { Route, Routes } from 'react-router-dom';
 import { KnowledgeBaseRouter } from './knowledge/base';
-import { HomeRootContainer } from '../features/Home/Root/HomeRootContainer';
+import { HomeRootContainer } from '@/features/Home/Root/HomeRootContainer';
+import { NotFoundPresentational } from '@/features/Error/NotFound/NotFoundPresentational';
 
 export const AppRouter = () => {
   return (
     <Routes>
       <Route path='/' element={<HomeRootContainer />} />
       <Route path='/knowledge/*' element={<KnowledgeBaseRouter />} />
+      <Route path='/*' element={<NotFoundPresentational />} />
     </Routes>
   );
 };

--- a/src/routes/knowledge/base.tsx
+++ b/src/routes/knowledge/base.tsx
@@ -1,10 +1,12 @@
 import { Route, Routes } from 'react-router-dom';
 import { KnowledgeContainer } from '@/features/Knowledge/Root/KnowledgeContainer';
+import { NotFoundPresentational } from '@/features/Error/NotFound/NotFoundPresentational';
 
 export const KnowledgeBaseRouter = () => {
   return (
     <Routes>
       <Route path='/' element={<KnowledgeContainer />} />
+      <Route path='*' element={<NotFoundPresentational />} />
     </Routes>
   );
 };


### PR DESCRIPTION
## 概要

- 存在しないurlを叩いた際に表示される404ページの作成

## 変更内容

- ルーティング設定を更新し、存在しないパスへアクセスした場合に404ページへリダイレクトされるように変更
- 404ページのUIコンポーネントを新規追加
- 404ページのテストを作成
 
## 画面表示

  - 404画面
<img width="1290" height="605" alt="スクリーンショット 2025-10-30 19 30 49" src="https://github.com/user-attachments/assets/25fafe21-239b-4fd7-8ac5-6a9207354bf5" />


## 影響範囲

-  なし

## 該当タスク
https://novel-team.atlassian.net/browse/MRIS-59

